### PR TITLE
feat: Implement extensive guidance system up to Ender Dragon fight

### DIFF
--- a/WayaCreateDatapack/data/minecraft/tags/functions/load.json
+++ b/WayaCreateDatapack/data/minecraft/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "wcs:utils/load_setups"
+  ]
+}

--- a/WayaCreateDatapack/data/minecraft/tags/functions/tick.json
+++ b/WayaCreateDatapack/data/minecraft/tags/functions/tick.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "wcs:item_abilities/check_item_usage",
+    "wcs:chat_commands/process_triggers"
+  ]
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/build_shelter.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/build_shelter.json
@@ -1,0 +1,27 @@
+{
+  "display": {
+    "title": "Home Sweet Hovel!",
+    "description": "You've built a basic shelter by placing a door.",
+    "icon": {
+      "item": "minecraft:oak_door"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "after": "wcs:story/craft_torches"
+  },
+  "criteria": {
+    "placed_door": {
+      "trigger": "minecraft:placed_block",
+      "conditions": {
+        "item": {
+          "tag": "minecraft:doors"
+        }
+      }
+    }
+  },
+  "rewards": {
+    "function": "wcs:advancements/story/reward_build_shelter"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/cook_eat_food.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/cook_eat_food.json
@@ -1,0 +1,27 @@
+{
+  "display": {
+    "title": "Well Fed!",
+    "description": "You've cooked and eaten a nutritious meal.",
+    "icon": {
+      "item": "minecraft:cooked_beef"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "after": "wcs:story/build_shelter"
+  },
+  "criteria": {
+    "consumed_cooked_meat": {
+      "trigger": "minecraft:consume_item",
+      "conditions": {
+        "item": {
+          "tag": "wcs:cooked_meats"
+        }
+      }
+    }
+  },
+  "rewards": {
+    "function": "wcs:advancements/story/reward_cook_eat_food"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/craft_crafting_table.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/craft_crafting_table.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "title": "Getting Crafty!",
+    "description": "You've crafted your first Crafting Table.",
+    "icon": {
+      "item": "minecraft:crafting_table"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "after": "wcs:story/get_first_log"
+  },
+  "criteria": {
+    "has_crafting_table": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": ["minecraft:crafting_table"]
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "wcs:advancements/story/reward_craft_crafting_table"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/craft_diamond_pickaxe.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/craft_diamond_pickaxe.json
@@ -1,0 +1,11 @@
+{
+  "display": {
+    "title": "Diamond Tipped",
+    "description": "You've crafted a Diamond Pickaxe, ready for tough materials.",
+    "icon": { "item": "minecraft:diamond_pickaxe" },
+    "frame": "task", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/get_diamond"
+  },
+  "criteria": { "has_diamond_pickaxe": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "items": ["minecraft:diamond_pickaxe"] }] }}},
+  "rewards": { "function": "wcs:advancements/story/reward_craft_diamond_pickaxe" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/craft_eyes_of_ender.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/craft_eyes_of_ender.json
@@ -1,0 +1,9 @@
+{
+  "display": {
+    "title": "The Eyes Have It", "description": "You've crafted at least 12 Eyes of Ender.",
+    "icon": { "item": "minecraft:ender_eye" }, "frame": "task", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/get_blaze_rods"
+  },
+  "criteria": { "has_eyes": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "items": ["minecraft:ender_eye"], "count": { "min": 12 } }] }}},
+  "rewards": { "function": "wcs:advancements/story/reward_craft_eyes_of_ender" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/craft_full_iron_gear.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/craft_full_iron_gear.json
@@ -1,0 +1,26 @@
+{
+  "display": {
+    "title": "Fully Kitted!",
+    "description": "You've crafted a full set of iron armor and main iron tools.",
+    "icon": {
+      "item": "minecraft:iron_chestplate"
+    },
+    "frame": "goal",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "after": "wcs:story/get_iron_ingot"
+  },
+  "criteria": {
+    "has_iron_helmet": {"trigger": "minecraft:inventory_changed","conditions": {"items": [{"items": ["minecraft:iron_helmet"]}]}},
+    "has_iron_chestplate": {"trigger": "minecraft:inventory_changed","conditions": {"items": [{"items": ["minecraft:iron_chestplate"]}]}},
+    "has_iron_leggings": {"trigger": "minecraft:inventory_changed","conditions": {"items": [{"items": ["minecraft:iron_leggings"]}]}},
+    "has_iron_boots": {"trigger": "minecraft:inventory_changed","conditions": {"items": [{"items": ["minecraft:iron_boots"]}]}},
+    "has_iron_pickaxe": {"trigger": "minecraft:inventory_changed","conditions": {"items": [{"items": ["minecraft:iron_pickaxe"]}]}},
+    "has_iron_axe": {"trigger": "minecraft:inventory_changed","conditions": {"items": [{"items": ["minecraft:iron_axe"]}]}},
+    "has_iron_sword": {"trigger": "minecraft:inventory_changed","conditions": {"items": [{"items": ["minecraft:iron_sword"]}]}}
+  },
+  "rewards": {
+    "function": "wcs:advancements/story/reward_craft_full_iron_gear"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/craft_stone_pickaxe.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/craft_stone_pickaxe.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "title": "Stone Age!",
+    "description": "You've crafted your first Stone Pickaxe.",
+    "icon": {
+      "item": "minecraft:stone_pickaxe"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "after": "wcs:story/craft_wooden_tools"
+  },
+  "criteria": {
+    "has_stone_pickaxe": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": ["minecraft:stone_pickaxe"]
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "wcs:advancements/story/reward_craft_stone_pickaxe"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/craft_torches.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/craft_torches.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "title": "Let There Be Light!",
+    "description": "You've crafted torches to light your way.",
+    "icon": {
+      "item": "minecraft:torch"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "after": "wcs:story/craft_stone_pickaxe"
+  },
+  "criteria": {
+    "has_torches": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {"items": [{"items": ["minecraft:torch"]}]}
+    }
+  },
+  "rewards": {
+    "function": "wcs:advancements/story/reward_craft_torches"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/craft_wooden_tools.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/craft_wooden_tools.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "title": "Tooling Up!",
+    "description": "You've crafted basic wooden tools.",
+    "icon": {
+      "item": "minecraft:wooden_pickaxe"
+    },
+    "frame": "goal",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "after": "wcs:story/craft_crafting_table"
+  },
+  "criteria": {
+    "has_wooden_pickaxe": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {"items": [{"items": ["minecraft:wooden_pickaxe"]}]}
+    },
+    "has_wooden_axe": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {"items": [{"items": ["minecraft:wooden_axe"]}]}
+    },
+    "has_wooden_shovel": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {"items": [{"items": ["minecraft:wooden_shovel"]}]}
+    }
+  },
+  "rewards": {
+    "function": "wcs:advancements/story/reward_craft_wooden_tools"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/enter_nether.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/enter_nether.json
@@ -1,0 +1,11 @@
+{
+  "display": {
+    "title": "We Need to Go Deeper",
+    "description": "You've entered the fiery dimension of the Nether.",
+    "icon": { "item": "minecraft:flint_and_steel" },
+    "frame": "goal", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/mine_obsidian"
+  },
+  "criteria": { "entered_nether": { "trigger": "minecraft:changed_dimension", "conditions": { "to": "minecraft:the_nether" }}},
+  "rewards": { "function": "wcs:advancements/story/reward_enter_nether" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/enter_the_end.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/enter_the_end.json
@@ -1,0 +1,9 @@
+{
+  "display": {
+    "title": "The End...?", "description": "You have arrived in the End dimension.",
+    "icon": { "item": "minecraft:end_stone" }, "frame": "goal", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/prepare_to_enter_end"
+  },
+  "criteria": { "entered_end": { "trigger": "minecraft:changed_dimension", "conditions": { "to": "minecraft:the_end" }}},
+  "rewards": { "function": "wcs:advancements/story/reward_enter_the_end" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/find_nether_fortress.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/find_nether_fortress.json
@@ -1,0 +1,16 @@
+{
+  "display": {
+    "title": "A Terrible Place",
+    "description": "You've found a Nether Fortress.",
+    "icon": { "item": "minecraft:nether_bricks" },
+    "frame": "task", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/enter_nether"
+  },
+  "criteria": {
+    "in_fortress": {
+      "trigger": "minecraft:location",
+      "conditions": { "feature": "minecraft:fortress" }
+    }
+  },
+  "rewards": { "function": "wcs:advancements/story/reward_find_nether_fortress" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/get_blaze_rods.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/get_blaze_rods.json
@@ -1,0 +1,11 @@
+{
+  "display": {
+    "title": "Into the Fire",
+    "description": "You've collected 5 Blaze Rods.",
+    "icon": { "item": "minecraft:blaze_rod" },
+    "frame": "task", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/find_nether_fortress"
+  },
+  "criteria": { "has_blaze_rods": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "items": ["minecraft:blaze_rod"], "count": { "min": 5 } }] }}},
+  "rewards": { "function": "wcs:advancements/story/reward_get_blaze_rods" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/get_diamond.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/get_diamond.json
@@ -1,0 +1,11 @@
+{
+  "display": {
+    "title": "Diamonds!",
+    "description": "You've found your first precious Diamond!",
+    "icon": { "item": "minecraft:diamond" },
+    "frame": "task", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/craft_full_iron_gear"
+  },
+  "criteria": { "has_diamond": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "items": ["minecraft:diamond"] }] }}},
+  "rewards": { "function": "wcs:advancements/story/reward_get_diamond" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/get_first_log.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/get_first_log.json
@@ -1,0 +1,28 @@
+{
+  "display": {
+    "title": "The Adventure Begins!",
+    "description": "You've gathered your first wood.",
+    "icon": {
+      "item": "minecraft:oak_log"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "criteria": {
+    "has_any_log": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "minecraft:logs"
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "wcs:advancements/story/reward_get_first_log"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/get_iron_ingot.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/get_iron_ingot.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "title": "Acquire Hardware",
+    "description": "You've smelted your first Iron Ingot!",
+    "icon": {
+      "item": "minecraft:iron_ingot"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
+    "after": "wcs:story/cook_eat_food"
+  },
+  "criteria": {
+    "has_iron_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": ["minecraft:iron_ingot"]
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "wcs:advancements/story/reward_get_iron_ingot"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/locate_stronghold.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/locate_stronghold.json
@@ -1,0 +1,9 @@
+{
+  "display": {
+    "title": "At the Threshold", "description": "You've located a Stronghold.",
+    "icon": { "item": "minecraft:stone_bricks" }, "frame": "task", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/craft_eyes_of_ender"
+  },
+  "criteria": { "in_stronghold": { "trigger": "minecraft:location", "conditions": { "feature": "minecraft:stronghold" }}},
+  "rewards": { "function": "wcs:advancements/story/reward_locate_stronghold" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/mine_obsidian.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/mine_obsidian.json
@@ -1,0 +1,11 @@
+{
+  "display": {
+    "title": "Obsidian Collector",
+    "description": "You've gathered enough Obsidian for a Nether Portal.",
+    "icon": { "item": "minecraft:obsidian" },
+    "frame": "task", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/craft_diamond_pickaxe"
+  },
+  "criteria": { "has_obsidian": { "trigger": "minecraft:inventory_changed", "conditions": { "items": [{ "items": ["minecraft:obsidian"], "count": { "min": 10 } }] }}},
+  "rewards": { "function": "wcs:advancements/story/reward_mine_obsidian" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/prepare_to_enter_end.json
+++ b/WayaCreateDatapack/data/wcs/advancements/story/prepare_to_enter_end.json
@@ -1,0 +1,9 @@
+{
+  "display": {
+    "title": "Portal Primed!", "description": "You've used an Eye of Ender, likely at the End Portal.",
+    "icon": { "item": "minecraft:end_portal_frame" }, "frame": "task", "show_toast": true, "announce_to_chat": true, "hidden": false,
+    "after": "wcs:story/locate_stronghold"
+  },
+  "criteria": { "used_eye": { "trigger": "minecraft:used_item", "conditions": { "item": { "items": ["minecraft:ender_eye"] }}}},
+  "rewards": { "function": "wcs:advancements/story/reward_prepare_to_enter_end" }
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_build_shelter.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_build_shelter.mcfunction
@@ -1,0 +1,6 @@
+execute if score @s wcs.progressStage matches 5 run {
+    scoreboard players set @s wcs.progressStage 6,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] Simon says: Shelter established! Safe and sound... for now. See your Guidebook!","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"},
+    recipe give @s wcs:item_placeholder_hunters_jerky
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_cook_eat_food.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_cook_eat_food.mcfunction
@@ -1,0 +1,6 @@
+execute if score @s wcs.progressStage matches 6 run {
+    scoreboard players set @s wcs.progressStage 7,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: Aah, a satisfying meal! Energy restored. Check your Guidebook.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"}
+    # Placeholder: recipe give @s wcs:item_placeholder_iron_guide
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_crafting_table.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_crafting_table.mcfunction
@@ -1,0 +1,5 @@
+execute if score @s wcs.progressStage matches 1 run {
+    scoreboard players set @s wcs.progressStage 2,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] Simon says: Crafting table made! You're a natural! Check your Guidebook.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"}
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_diamond_pickaxe.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_diamond_pickaxe.mcfunction
@@ -1,0 +1,5 @@
+execute if score @s wcs.progressStage matches 10 run {
+    scoreboard players set @s wcs.progressStage 11,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: Diamond Pickaxe crafted! Now you can mine Obsidian. See your Guidebook.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"}
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_full_iron_gear.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_full_iron_gear.mcfunction
@@ -1,0 +1,6 @@
+execute if score @s wcs.progressStage matches 8 run {
+    scoreboard players set @s wcs.progressStage 9,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: Looking sharp and well-protected in your iron gear! Time for the next hunt. See your Guidebook.","color":"light_purple"},
+    title @s title {"text":"Goal Achieved!","color":"green"},
+    recipe give @s wcs:item_placeholder_diamond_dowser
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_stone_pickaxe.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_stone_pickaxe.mcfunction
@@ -1,0 +1,5 @@
+execute if score @s wcs.progressStage matches 3 run {
+    scoreboard players set @s wcs.progressStage 4,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] Simon says: Stone pickaxe acquired! Much sturdier. Check your Guidebook!","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"}
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_torches.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_torches.mcfunction
@@ -1,0 +1,6 @@
+execute if score @s wcs.progressStage matches 4 run {
+    scoreboard players set @s wcs.progressStage 5,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: Torches crafted! Darkness, be gone! See your Guidebook.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"}
+    # Placeholder: recipe give @s wcs:item_placeholder_shelter_guide
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_wooden_tools.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_craft_wooden_tools.mcfunction
@@ -1,0 +1,6 @@
+execute if score @s wcs.progressStage matches 2 run {
+    scoreboard players set @s wcs.progressStage 3,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: All wooden tools crafted! You're getting the hang of this!","color":"light_purple"},
+    title @s title {"text":"Goal Achieved!","color":"green"}
+    # Placeholder: recipe give @s wcs:item_placeholder_stone_miner_charm
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_enter_nether.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_enter_nether.mcfunction
@@ -1,0 +1,7 @@
+execute if score @s wcs.progressStage matches 12 run {
+    scoreboard players set @s wcs.progressStage 13,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: Welcome to the Nether! A dangerous but rewarding place. See your Guidebook.","color":"light_purple"},
+    title @s title {"text":"Goal Achieved!","color":"green"},
+    recipe give @s wcs:item_placeholder_fortress_finder,
+    recipe give @s wcs:item_placeholder_pact_of_friendship
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_find_nether_fortress.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_find_nether_fortress.mcfunction
@@ -1,0 +1,5 @@
+execute if score @s wcs.progressStage matches 13 run {
+    scoreboard players set @s wcs.progressStage 14,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] Simon says: You found a Nether Fortress! Watch out for Blazes and Wither Skeletons. Guidebook updated.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"}
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_get_blaze_rods.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_get_blaze_rods.mcfunction
@@ -1,0 +1,6 @@
+execute if score @s wcs.progressStage matches 14 run {
+    scoreboard players set @s wcs.progressStage 15,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: 5 Blaze Rods secured! These are key to reaching The End. See your Guidebook.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"},
+    recipe give @s wcs:item_placeholder_eye_of_ender_guide
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_get_diamond.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_get_diamond.mcfunction
@@ -1,0 +1,6 @@
+execute if score @s wcs.progressStage matches 9 run {
+    scoreboard players set @s wcs.progressStage 10,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] Simon says: A Diamond! Excellent find! Check your Guidebook.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"},
+    recipe give @s wcs:item_placeholder_nether_portal_kit
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_get_first_log.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_get_first_log.mcfunction
@@ -1,0 +1,9 @@
+execute if score @s wcs.progressStage matches 0 run {
+    scoreboard players set @s wcs.progressStage 1,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: You got wood! Excellent! Check your Guidebook for the next step!","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"},
+    recipe give @s wcs:crafting_scroll,
+    recipe give @s wcs:lumberjack_aid,
+    execute store success score @s wcs.temp run clear @s minecraft:carrot_on_a_stick{wcs_item:"guidebook"} 0,
+    execute if score @s wcs.temp matches 0 run give @s minecraft:carrot_on_a_stick{display:{Name:'{\"text\":\"WayaCreate\\\'s Guidebook\",\"color\":\"gold\",\"italic\":false}',Lore:['{\"text\":\"Right-click to get guidance on your journey!\",\"color\":\"yellow\"}']},wcs_item:\"guidebook\",CustomModelData:1} 1
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_get_iron_ingot.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_get_iron_ingot.mcfunction
@@ -1,0 +1,7 @@
+execute if score @s wcs.progressStage matches 7 run {
+    scoreboard players set @s wcs.progressStage 8,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] Simon says: Iron Ingot acquired! Stronger tools and armor await. See your Guidebook!","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"},
+    recipe give @s wcs:hearthstone,
+    recipe give @s wcs:item_placeholder_iron_tools_guide
+}

--- a/WayaCreateDatapack/data/wcs/advancements/story/reward_mine_obsidian.mcfunction
+++ b/WayaCreateDatapack/data/wcs/advancements/story/reward_mine_obsidian.mcfunction
@@ -1,0 +1,5 @@
+execute if score @s wcs.progressStage matches 11 run {
+    scoreboard players set @s wcs.progressStage 12,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] Simon says: 10 Obsidian collected! You're ready to build a gateway to another dimension!","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"}
+}

--- a/WayaCreateDatapack/data/wcs/functions/advancements/story/reward_craft_eyes_of_ender.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/advancements/story/reward_craft_eyes_of_ender.mcfunction
@@ -1,0 +1,6 @@
+execute if score @s wcs.progressStage matches 15 run {
+    scoreboard players set @s wcs.progressStage 16,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] Simon says: Eyes of Ender crafted! Time to find that Stronghold. Guidebook updated.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"},
+    recipe give @s wcs:item_placeholder_divining_rod
+}

--- a/WayaCreateDatapack/data/wcs/functions/advancements/story/reward_enter_the_end.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/advancements/story/reward_enter_the_end.mcfunction
@@ -1,0 +1,5 @@
+execute if score @s wcs.progressStage matches 18 run {
+    scoreboard players set @s wcs.progressStage 19,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: You're in The End! Destroy those crystals, then fight the Dragon!","color":"light_purple"},
+    title @s title {"text":"Welcome to The End!","color":"dark_purple"}
+}

--- a/WayaCreateDatapack/data/wcs/functions/advancements/story/reward_locate_stronghold.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/advancements/story/reward_locate_stronghold.mcfunction
@@ -1,0 +1,5 @@
+execute if score @s wcs.progressStage matches 16 run {
+    scoreboard players set @s wcs.progressStage 17,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] WayaCreate says: Stronghold found! Now search for the End Portal room within. Guidebook updated.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"}
+}

--- a/WayaCreateDatapack/data/wcs/functions/advancements/story/reward_prepare_to_enter_end.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/advancements/story/reward_prepare_to_enter_end.mcfunction
@@ -1,0 +1,6 @@
+execute if score @s wcs.progressStage matches 17 run {
+    scoreboard players set @s wcs.progressStage 18,
+    tellraw @s {"text":"[GUIDEBOOK UPDATED] Simon says: Portal ready (or you're about to make it so)! The End awaits. Steel yourself! Guidebook updated.","color":"light_purple"},
+    title @s title {"text":"Task Complete!","color":"green"},
+    recipe give @s wcs:item_placeholder_dragon_slayers_brew
+}

--- a/WayaCreateDatapack/data/wcs/functions/chat_commands/main.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/chat_commands/main.mcfunction
@@ -1,0 +1,17 @@
+tellraw @s ""
+tellraw @s {"text":"--- WayaCreate Says - Chat Commands ---","color":"gold"}
+tellraw @s {"text":"Click a command below or type it. You may need to type it once to enable it.","color":"yellow"}
+tellraw @s ["",{"text":"[Help]","color":"green","clickEvent":{"action":"suggest_command","value":"/trigger wcs.cmd_help set 1"},"hoverEvent":{"action":"show_text","contents":"Show this help message"}}]
+tellraw @s ["",{"text":"[Give Diamonds]","color":"aqua","clickEvent":{"action":"suggest_command","value":"/trigger wcs.cmd_giveDia set 1"},"hoverEvent":{"action":"show_text","contents":"Get a stack of diamonds"}}]
+tellraw @s ["",{"text":"[Time Stop]","color":"aqua","clickEvent":{"action":"suggest_command","value":"/trigger wcs.cmd_timeStop set 1"},"hoverEvent":{"action":"show_text","contents":"Freeze time at noon"}}]
+tellraw @s ["",{"text":"[Time Resume]","color":"aqua","clickEvent":{"action":"suggest_command","value":"/trigger wcs.cmd_timeResume set 1"},"hoverEvent":{"action":"show_text","contents":"Let time flow normally"}}]
+tellraw @s ["",{"text":"[WayaCreate Mode ON]","color":"red","clickEvent":{"action":"suggest_command","value":"/trigger wcs.cmd_wcModeOn set 1"},"hoverEvent":{"action":"show_text","contents":"Activate WayaCreate Mode"}}]
+tellraw @s ["",{"text":"[WayaCreate Mode OFF]","color":"red","clickEvent":{"action":"suggest_command","value":"/trigger wcs.cmd_wcModeOff set 1"},"hoverEvent":{"action":"show_text","contents":"Deactivate WayaCreate Mode"}}]
+
+# Enable triggers for the player so they can click them
+scoreboard players enable @s wcs.cmd_help
+scoreboard players enable @s wcs.cmd_giveDia
+scoreboard players enable @s wcs.cmd_timeStop
+scoreboard players enable @s wcs.cmd_timeResume
+scoreboard players enable @s wcs.cmd_wcModeOn
+scoreboard players enable @s wcs.cmd_wcModeOff

--- a/WayaCreateDatapack/data/wcs/functions/chat_commands/process_triggers.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/chat_commands/process_triggers.mcfunction
@@ -1,0 +1,28 @@
+# Process Help Command
+execute as @a[scores={wcs.cmd_help=1..}] run function wcs:chat_commands/main
+execute as @a[scores={wcs.cmd_help=1..}] run scoreboard players set @s wcs.cmd_help 0
+
+# Process Give Diamonds
+execute as @a[scores={wcs.cmd_giveDia=1..}] run function wcs:game_control/give_diamonds_cheat
+execute as @a[scores={wcs.cmd_giveDia=1..}] run scoreboard players enable @s wcs.cmd_giveDia
+execute as @a[scores={wcs.cmd_giveDia=1..}] run scoreboard players set @s wcs.cmd_giveDia 0
+
+# Process Time Stop
+execute as @a[scores={wcs.cmd_timeStop=1..}] run function wcs:game_control/time_stop
+execute as @a[scores={wcs.cmd_timeStop=1..}] run scoreboard players enable @s wcs.cmd_timeStop
+execute as @a[scores={wcs.cmd_timeStop=1..}] run scoreboard players set @s wcs.cmd_timeStop 0
+
+# Process Time Resume
+execute as @a[scores={wcs.cmd_timeResume=1..}] run function wcs:game_control/time_resume
+execute as @a[scores={wcs.cmd_timeResume=1..}] run scoreboard players enable @s wcs.cmd_timeResume
+execute as @a[scores={wcs.cmd_timeResume=1..}] run scoreboard players set @s wcs.cmd_timeResume 0
+
+# Process WayaCreate Mode ON
+execute as @a[scores={wcs.cmd_wcModeOn=1..}] run function wcs:game_control/init_wayacreate_mode
+execute as @a[scores={wcs.cmd_wcModeOn=1..}] run scoreboard players enable @s wcs.cmd_wcModeOn
+execute as @a[scores={wcs.cmd_wcModeOn=1..}] run scoreboard players set @s wcs.cmd_wcModeOn 0
+
+# Process WayaCreate Mode OFF
+execute as @a[scores={wcs.cmd_wcModeOff=1..}] run function wcs:game_control/remove_wayacreate_mode
+execute as @a[scores={wcs.cmd_wcModeOff=1..}] run scoreboard players enable @s wcs.cmd_wcModeOff
+execute as @a[scores={wcs.cmd_wcModeOff=1..}] run scoreboard players set @s wcs.cmd_wcModeOff 0

--- a/WayaCreateDatapack/data/wcs/functions/game_control/automate_crafting_stub.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/automate_crafting_stub.mcfunction
@@ -1,0 +1,2 @@
+# Placeholder/Stub function for now.
+tellraw @s {"text":"WayaCreate says: Automated Crafting is a grand vision! Picture villagers crafting items on demand! (Not yet implemented)","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/game_control/automate_mining_stub.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/automate_mining_stub.mcfunction
@@ -1,0 +1,3 @@
+# Placeholder/Stub function for now.
+tellraw @s {"text":"WayaCreate says: Automated Mining is a complex system yet to be fully built! Imagine villagers mining for you!","color":"gray"}
+# Future idea: summon a temporary "mining golem" that clears a small area.

--- a/WayaCreateDatapack/data/wcs/functions/game_control/build_nether_portal.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/build_nether_portal.mcfunction
@@ -1,0 +1,9 @@
+# Simplified: Assumes player has 10 obsidian and flint/steel.
+# Builds a 2x3 portal (4x5 outer frame) in front of the player.
+# Horizontal portal, y, y+1, y+2 for portal blocks. y-1 and y+3 for bottom/top obsidian.
+# x, x+1, x+2, x+3 for width. z for depth.
+# This is a basic example and doesn't check for space or existing blocks.
+execute at @s anchored eyes run fill ^ ^-2 ^1 ^3 ^2 ^1 minecraft:obsidian
+execute at @s anchored eyes run fill ^1 ^-1 ^1 ^2 ^1 ^1 minecraft:air
+execute at @s anchored eyes run setblock ^1 ^-1 ^1 minecraft:fire
+tellraw @s {"text":"WayaCreate says: Nether portal constructed! (Hopefully it's in a good spot!)","color":"purple"}

--- a/WayaCreateDatapack/data/wcs/functions/game_control/find_stronghold.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/find_stronghold.mcfunction
@@ -1,0 +1,5 @@
+execute in minecraft:overworld run locate structure minecraft:stronghold
+# The above command only outputs to server console/logs, not directly to player chat in a usable way via function alone.
+# We need a helper entity or tellraw trick to show the coordinates to the player.
+# For now, just a message saying it was located (admin would see coords in log).
+tellraw @s {"text":"WayaCreate says: Attempting to locate stronghold... (Admins: check server log for coords). A better system for this is needed.","color":"dark_aqua"}

--- a/WayaCreateDatapack/data/wcs/functions/game_control/give_diamonds_cheat.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/give_diamonds_cheat.mcfunction
@@ -1,0 +1,2 @@
+give @s minecraft:diamond 64
+tellraw @s {"text":"WayaCreate says: Sparkle sparkle! Here are some diamonds!","color":"light_purple"}

--- a/WayaCreateDatapack/data/wcs/functions/game_control/init_wayacreate_mode.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/init_wayacreate_mode.mcfunction
@@ -1,0 +1,8 @@
+effect give @s minecraft:health_boost 300 4 true
+effect give @s minecraft:absorption 300 4 true
+effect give @s minecraft:speed 300 1 true
+effect give @s minecraft:jump_boost 300 1 true
+effect give @s minecraft:slow_falling 300 0 true
+# Add a tag to player to signify mode is active
+tag @s add wcs.wayacreate_mode_active
+tellraw @s {"text":"WayaCreate Mode Activated! You feel stronger, faster, and lighter!","color":"gold"}

--- a/WayaCreateDatapack/data/wcs/functions/game_control/make_crafting_table.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/make_crafting_table.mcfunction
@@ -1,0 +1,6 @@
+scoreboard players add @s wcs.temp 0
+execute store result score #has_planks wcs.temp run clear @s minecraft:oak_planks 0
+execute if score #has_planks wcs.temp matches 4.. run clear @s minecraft:oak_planks 4
+execute if score #has_planks wcs.temp matches 4.. run give @s minecraft:crafting_table 1
+execute if score #has_planks wcs.temp matches 4.. run tellraw @s {"text":"WayaCreate says: A crafting table has been provided!","color":"gold"}
+execute if score #has_planks wcs.temp matches ..3 run tellraw @s {"text":"WayaCreate says: You need at least 4 oak planks to make a crafting table!","color":"red"}

--- a/WayaCreateDatapack/data/wcs/functions/game_control/mine_wood.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/mine_wood.mcfunction
@@ -1,0 +1,11 @@
+tellraw @s {"text":"WayaCreate says: Let's get chopping! (This feature is basic and will try to mine one log in front of you)","color":"green"}
+# This is a simplified version. It targets a single log block directly in front of the player at eye level.
+# A full version would require raycasting or checking a larger area and different wood types.
+execute at @s anchored eyes positioned ^ ^ ^1 execute if block ~ ~ ~ minecraft:oak_log run setblock ~ ~ ~ minecraft:air destroy
+execute at @s anchored eyes positioned ^ ^ ^1 execute if block ~ ~ ~ minecraft:spruce_log run setblock ~ ~ ~ minecraft:air destroy
+execute at @s anchored eyes positioned ^ ^ ^1 execute if block ~ ~ ~ minecraft:birch_log run setblock ~ ~ ~ minecraft:air destroy
+# Add other log types as needed (dark_oak, acacia, jungle, mangrove, cherry, crimson_stem, warped_stem)
+# Potentially give item based on what was destroyed, or rely on 'destroy' dropping it.
+# Add a small cooldown to prevent spam/lag
+scoreboard players add @s wcs.mine_wood_cd 100
+schedule function wcs:utils/reset_mine_wood_cd 5s

--- a/WayaCreateDatapack/data/wcs/functions/game_control/remove_wayacreate_mode.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/remove_wayacreate_mode.mcfunction
@@ -1,0 +1,7 @@
+effect clear @s minecraft:health_boost
+effect clear @s minecraft:absorption
+effect clear @s minecraft:speed
+effect clear @s minecraft:jump_boost
+effect clear @s minecraft:slow_falling
+tag @s remove wcs.wayacreate_mode_active
+tellraw @s {"text":"WayaCreate Mode Deactivated.","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/game_control/teleport_spawn.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/teleport_spawn.mcfunction
@@ -1,0 +1,2 @@
+execute in minecraft:overworld run teleport @s 0 64 0
+tellraw @s {"text":"WayaCreate says: Woosh! Back to spawn!","color":"aqua"}

--- a/WayaCreateDatapack/data/wcs/functions/game_control/time_resume.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/time_resume.mcfunction
@@ -1,0 +1,2 @@
+gamerule doDaylightCycle true
+tellraw @s {"text":"WayaCreate says: Time resumes its flow!","color":"yellow"}

--- a/WayaCreateDatapack/data/wcs/functions/game_control/time_stop.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/game_control/time_stop.mcfunction
@@ -1,0 +1,3 @@
+gamerule doDaylightCycle false
+time set noon
+tellraw @s {"text":"ZA WARUDO! WayaCreate says: Time has stopped at high noon!","color":"yellow"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_0_intro.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_0_intro.mcfunction
@@ -1,0 +1,7 @@
+tellraw @s {"text":"Welcome, brave adventurer! I am WayaCreate's Guidebook, your companion on this journey!","color":"gold"}
+title @s subtitle {"text":"Let's begin your epic quest!","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s {"text":"Your first task is simple, yet vital:","color":"white"}
+tellraw @s ["",{"text":"Punch a tree to gather your first piece of ","color":"white"},{"text":"Wood","color":"green","bold":true},"!",{"text":"","color":"white"}]
+tellraw @s {"text":"Once you have some wood, consult me again!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_10_craft_diamond_pickaxe.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_10_craft_diamond_pickaxe.mcfunction
@@ -1,0 +1,6 @@
+tellraw @s {"text":"Diamonds! You're rich! Well, almost.","color":"gold"}
+title @s subtitle {"text":"The key to the Nether...","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s ["",{"text":"Now that you have diamonds, craft a ","color":"white"},{"text":"Diamond Pickaxe","color":"aqua","bold":true},". It's the only tool that can mine Obsidian!","color":"white"}]
+tellraw @s {"text":"Consult me when your shiny new pickaxe is ready!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_11_mine_obsidian.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_11_mine_obsidian.mcfunction
@@ -1,0 +1,7 @@
+tellraw @s {"text":"That Diamond Pickaxe is a work of art!","color":"gold"}
+title @s subtitle {"text":"The stuff of portals...","color":"yellow"}
+title @s title {"text":"Simon Says:","color":"blue"}
+tellraw @s ""
+tellraw @s ["",{"text":"Now, find or create ","color":"white"},{"text":"Obsidian","color":"dark_purple","bold":true},". You get it when water flows over lava source blocks.","color":"white"}]
+tellraw @s {"text":"Mine at least 10 blocks of Obsidian. It's slow, even with diamond!","color":"white"}
+tellraw @s {"text":"Consult me when you have enough Obsidian.","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_12_build_nether_portal.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_12_build_nether_portal.mcfunction
@@ -1,0 +1,8 @@
+tellraw @s {"text":"Excellent! You have the key ingredient for a Nether Portal.","color":"gold"}
+title @s subtitle {"text":"To the Nether!","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s ["",{"text":"Construct a ","color":"white"},{"text":"Nether Portal","color":"purple","bold":true},{"text":" frame using your Obsidian (a 4x5 rectangle, leaving the 2x3 inner area hollow).","color":"white"}]
+tellraw @s ["",{"text":"Then, light the inside of the frame with ","color":"white"},{"text":"Flint and Steel","color":"orange"},{"text":".","color":"white"}]
+tellraw @s ["",{"text":"(Hint: The 'Nether Portal Kit' item you might have a recipe for can help!)","color":"gray"}]
+tellraw @s {"text":"Step into the portal and consult me once you've braved the Nether!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_13_find_fortress.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_13_find_fortress.mcfunction
@@ -1,0 +1,7 @@
+tellraw @s {"text":"The Nether... spooky, isn't it? But full of treasures!","color":"gold"}
+title @s subtitle {"text":"Fortress Quest!","color":"yellow"}
+title @s title {"text":"Simon Says:","color":"blue"}
+tellraw @s ""
+tellraw @s ["",{"text":"Your next major goal here is to find a ","color":"white"},{"text":"Nether Fortress","color":"dark_red","bold":true},{"text":". These dark brick structures hold valuable loot and dangerous foes.","color":"white"}]
+tellraw @s ["",{"text":"(Hint: You might have recipes for a 'Fortress Finder' or a 'Pact of Friendship' to help.)","color":"gray"}]
+tellraw @s {"text":"Explore carefully and consult me when you've found one!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_14_get_blaze_rods.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_14_get_blaze_rods.mcfunction
@@ -1,0 +1,7 @@
+tellraw @s {"text":"A Nether Fortress! Dangerous, but necessary.","color":"gold"}
+title @s subtitle {"text":"Fiery Foes Ahead!","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s ["",{"text":"Inside these fortresses, you'll find ","color":"white"},{"text":"Blazes","color":"orange","bold":true},{"text":", fiery elemental creatures.","color":"white"}]
+tellraw @s ["",{"text":"Defeat them to collect ","color":"white"},{"text":"Blaze Rods","color":"gold","bold":true},{"text":". You'll need at least 5. Be careful, they shoot fireballs!","color":"white"}]
+tellraw @s {"text":"Consult your Guidebook once you have enough Blaze Rods.","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_15_craft_eyes_of_ender.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_15_craft_eyes_of_ender.mcfunction
@@ -1,0 +1,8 @@
+tellraw @s {"text":"Blaze Rods acquired! You're braver than you look.","color":"gold"}
+title @s subtitle {"text":"The Eyes Have It...","color":"yellow"}
+title @s title {"text":"Simon Says:","color":"blue"}
+tellraw @s ""
+tellraw @s ["",{"text":"Next, you need to craft ","color":"white"},{"text":"Eyes of Ender","color":"light_purple","bold":true},{"text":".","color":"white"}]
+tellraw @s ["",{"text":"These are made from ","color":"white"},{"text":"Blaze Powder","color":"gold"},{"text":" (crafted from Blaze Rods) and ","color":"white"},{"text":"Ender Pearls","color":"dark_green"},{"text":" (dropped by Endermen).","color":"white"}]
+tellraw @s {"text":"You'll need around 12 Eyes of Ender to be safe. Consult me when you have them.","color":"gray"}
+tellraw @s ["",{"text":"(Hint: You might have an 'Essence Extractor' or 'Pact of Friendship' to help with Endermen.)","color":"gray"}]

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_16_locate_stronghold.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_16_locate_stronghold.mcfunction
@@ -1,0 +1,8 @@
+tellraw @s {"text":"Plenty of Eyes of Ender! You're well prepared.","color":"gold"}
+title @s subtitle {"text":"Finding the Fortress...","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s ["",{"text":"Throw an ","color":"white"},{"text":"Eye of Ender","color":"light_purple"},{"text":" into the air (right-click). It will fly towards the nearest Stronghold.","color":"white"}]
+tellraw @s {"text":"Follow it, but be prepared to throw more as they can break. When it goes underground, dig down!","color":"white"}
+tellraw @s ["",{"text":"(Hint: A 'Divining Rod' item might also help if you crafted it.)","color":"gray"}]
+tellraw @s {"text":"Consult me when you've arrived at a Stronghold!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_17_activate_end_portal.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_17_activate_end_portal.mcfunction
@@ -1,0 +1,7 @@
+tellraw @s {"text":"You're in a Stronghold! The air hums with strange energy.","color":"gold"}
+title @s subtitle {"text":"The Final Portal...","color":"yellow"}
+title @s title {"text":"Simon Says:","color":"blue"}
+tellraw @s ""
+tellraw @s ["",{"text":"Explore the Stronghold to find the ","color":"white"},{"text":"End Portal Room","color":"dark_purple","bold":true},{"text":".","color":"white"}]
+tellraw @s ["",{"text":"Place your ","color":"white"},{"text":"Eyes of Ender","color":"light_purple"},{"text":" into the empty slots in the portal frame to activate it.","color":"white"}]
+tellraw @s {"text":"Consult me once you've activated it, before you jump in!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_18_enter_the_end.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_18_enter_the_end.mcfunction
@@ -1,0 +1,8 @@
+tellraw @s {"text":"The End Portal is active, or you're about to make it so! A chilling wind blows from it...","color":"gold"}
+title @s subtitle {"text":"Face the Dragon!","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s {"text":"This is it! Jump into the portal to face the Ender Dragon.","color":"white"}
+tellraw @s ["",{"text":"Remember to destroy the ","color":"white"},{"text":"End Crystals","color":"magenta","bold":true},{"text":" on the obsidian towers first, as they heal the dragon!","color":"white"}]
+tellraw @s ["",{"text":"(Hint: A 'Dragon Slayer's Brew' might give you an edge!)","color":"gray"}]
+tellraw @s {"text":"Good luck, hero! Consult me in The End if you make it.","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_19_defeat_ender_dragon.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_19_defeat_ender_dragon.mcfunction
@@ -1,0 +1,6 @@
+tellraw @s {"text":"You're in The End! The air is thin and the Dragon looms.","color":"dark_purple"}
+title @s subtitle {"text":"Destroy the Crystals, then the Dragon!","color":"magenta"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s {"text":"Focus on destroying the End Crystals on the obsidian towers first. Arrows are good, or careful pillaring.","color":"white"}
+tellraw @s {"text":"Once the crystals are gone, attack the Ender Dragon when it perches on the central portal.","color":"white"}
+tellraw @s {"text":"Good luck! There's no turning back now!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_1_get_wood.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_1_get_wood.mcfunction
@@ -1,0 +1,8 @@
+tellraw @s {"text":"Well done gathering wood! Truly the work of a future champion!","color":"gold"}
+title @s subtitle {"text":"Time for the next step!","color":"yellow"}
+title @s title {"text":"Simon Says:","color":"blue"}
+tellraw @s ""
+tellraw @s {"text":"Now, open your inventory (default key 'E').","color":"white"}
+tellraw @s ["",{"text":"Turn those ","color":"white"},{"text":"Logs","color":"green"},{"text":" into ","color":"white"},{"text":"Planks","color":"green"},{"text":", then craft a ","color":"white"},{"text":"Crafting Table","color":"aqua","bold":true},"!",{"text":"","color":"white"}]
+tellraw @s ["",{"text":"(Hint: You might have a ","color":"gray"},{"text":"'Crafting Table Scroll'","color":"light_purple"},{"text":" recipe available if you check your recipe book!)","color":"gray"}]
+tellraw @s {"text":"Place it down and consult me again when you're ready!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_2_craft_tools.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_2_craft_tools.mcfunction
@@ -1,0 +1,11 @@
+# Player has crafting table (progressStage = 2)
+# Task: Craft Wooden Tools (Pickaxe, Axe, Shovel)
+tellraw @s {"text":"Excellent work on the crafting table!","color":"gold"}
+title @s subtitle {"text":"Time to make some tools!","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s {"text":"With your crafting table, make these essential wooden tools:","color":"white"}
+tellraw @s ["",{"text":"- A ","color":"white"},{"text":"Wooden Pickaxe","color":"green","bold":true}]
+tellraw @s ["",{"text":"- A ","color":"white"},{"text":"Wooden Axe","color":"green","bold":true}]
+tellraw @s ["",{"text":"- A ","color":"white"},{"text":"Wooden Shovel","color":"green","bold":true}]
+tellraw @s {"text":"These will be vital for your survival! Consult me when you have all three.","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_3_get_stone.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_3_get_stone.mcfunction
@@ -1,0 +1,8 @@
+# Player has wooden tools (progressStage = 3)
+# Task: Gather Cobblestone and Craft Stone Tools
+tellraw @s {"text":"Those wooden tools look great! But they won't last forever.","color":"gold"}
+title @s subtitle {"text":"Time for an upgrade!","color":"yellow"}
+title @s title {"text":"Simon Says:","color":"blue"}
+tellraw @s ""
+tellraw @s ["",{"text":"Use your ","color":"white"},{"text":"Wooden Pickaxe","color":"green"},{"text":" to mine at least 8 ","color":"white"},{"text":"Cobblestone","color":"gray","bold":true},"!",{"text":"","color":"white"}]
+tellraw @s {"text":"Then, craft a Stone Pickaxe. Consult your Guidebook after that!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_4_find_coal.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_4_find_coal.mcfunction
@@ -1,0 +1,10 @@
+# Player has stone pickaxe (progressStage = 4)
+# Task: Find Coal and Craft Torches
+tellraw @s {"text":"That stone pickaxe will serve you well!","color":"gold"}
+title @s subtitle {"text":"Let there be light!","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s {"text":"The underground can be dark and dangerous.","color":"white"}
+tellraw @s ["",{"text":"Search for ","color":"white"},{"text":"Coal Ore","color":"dark_gray","bold":true},{"text":" (black speckles in stone) and mine it.","color":"white"}]
+tellraw @s ["",{"text":"Then, craft some ","color":"white"},{"text":"Torches","color":"yellow","bold":true},{"text":" using coal and sticks.","color":"white"}]
+tellraw @s {"text":"Light your way and consult me when you have torches!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_5_build_shelter.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_5_build_shelter.mcfunction
@@ -1,0 +1,9 @@
+# Player has torches (progressStage = 5)
+# Task: Build a Simple Shelter
+tellraw @s {"text":"With torches in hand, you can now explore more safely!","color":"gold"}
+title @s subtitle {"text":"Home Sweet Home (for now)","color":"yellow"}
+title @s title {"text":"Simon Says:","color":"blue"}
+tellraw @s ""
+tellraw @s {"text":"Nightfall brings dangers. It's time to build a basic shelter.","color":"white"}
+tellraw @s ["",{"text":"Use your blocks (wood, cobblestone) to make a small enclosed space. Don't forget a ","color":"white"},{"text":"Door","color":"brown","bold":true},"!",{"text":"","color":"white"}]
+tellraw @s {"text":"A simple box will do for your first night. Consult me once you've placed a door on your shelter.","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_6_get_food.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_6_get_food.mcfunction
@@ -1,0 +1,10 @@
+# Player has built a shelter (progressStage = 6)
+# Task: Gather Food
+tellraw @s {"text":"A cozy shelter! Excellent work.","color":"gold"}
+title @s subtitle {"text":"A hero needs to eat!","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s {"text":"Adventuring is hungry work. It's time to find some food.","color":"white"}
+tellraw @s ["",{"text":"Hunt some animals (like pigs, cows, sheep) and cook their meat in a ","color":"white"},{"text":"Furnace","color":"gray","bold":true},". Or gather edible plants!","color":"white"}]
+tellraw @s ["",{"text":"(Hint: You might have a recipe for ","color":"gray"},{"text":"'Hunter's Jerky'","color":"dark_red"},{"text":" to help!)","color":"gray"}]
+tellraw @s {"text":"Consult me after you've eaten some cooked food.","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_7_find_iron.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_7_find_iron.mcfunction
@@ -1,0 +1,10 @@
+# Player has eaten (progressStage = 7)
+# Task: Mine Iron Ore and Smelt Iron Ingots
+tellraw @s {"text":"Feeling full and ready for action!","color":"gold"}
+title @s subtitle {"text":"Time to get serious: Iron!","color":"yellow"}
+title @s title {"text":"Simon Says:","color":"blue"}
+tellraw @s ""
+tellraw @s {"text":"Your next big step is to find Iron Ore.","color":"white"}
+tellraw @s ["",{"text":"Look for stone with ","color":"white"},{"text":"light brown/orange speckles","color":"gold","bold":true},{"text":" underground. You'll need your Stone Pickaxe.","color":"white"}]
+tellraw @s ["",{"text":"Smelt the Iron Ore in a ","color":"white"},{"text":"Furnace","color":"gray"},{"text":" to create Iron Ingots.","color":"white"}]
+tellraw @s {"text":"Consult me once you have your first Iron Ingot!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_8_craft_iron_gear.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_8_craft_iron_gear.mcfunction
@@ -1,0 +1,10 @@
+# Player has iron ingot (progressStage = 8)
+# Task: Craft a Full Set of Iron Armor and Iron Tools
+tellraw @s {"text":"That shiny Iron Ingot is the key to better gear!","color":"gold"}
+title @s subtitle {"text":"Suit Up!","color":"yellow"}
+title @s title {"text":"WayaCreate Says:","color":"gold"}
+tellraw @s ""
+tellraw @s {"text":"It's time to craft a full set of Iron Armor and essential Iron Tools:","color":"white"}
+tellraw @s ["",{"text":"- Iron: ","color":"white"},{"text":"Helmet, Chestplate, Leggings, Boots","color":"gray","bold":true}]
+tellraw @s ["",{"text":"- Iron: ","color":"white"},{"text":"Pickaxe, Axe, Sword","color":"gray","bold":true}]
+tellraw @s {"text":"This will greatly improve your survivability and efficiency! Consult me when you're fully equipped.","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/guidance/stage_9_find_diamonds.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/guidance/stage_9_find_diamonds.mcfunction
@@ -1,0 +1,10 @@
+# Player has full iron gear (progressStage = 9)
+# Task: Find Diamonds
+tellraw @s {"text":"With that iron gear, you're ready for deeper challenges!","color":"gold"}
+title @s subtitle {"text":"Sparkling Treasures Await!","color":"yellow"}
+title @s title {"text":"Simon Says:","color":"blue"}
+tellraw @s ""
+tellraw @s {"text":"The next crucial resource is ","color":"white"},{"text":"Diamonds","color":"aqua","bold":true},{"text":"!","color":"white"}
+tellraw @s ["",{"text":"Mine deep underground, typically between Y-levels -50 and -64. They are rare, so be patient!","color":"white"}]
+tellraw @s ["",{"text":"(Hint: You might have a recipe for a ","color":"gray"},{"text":"'Diamond Dowser'","color":"cyan"},{"text":" to help your search.)","color":"gray"}]
+tellraw @s {"text":"Consult me once you've found your first Diamond!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/item_abilities/check_item_usage.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/item_abilities/check_item_usage.mcfunction
@@ -1,0 +1,14 @@
+# Check for Guidebook
+execute as @a[scores={wcs.use_item=1..},nbt={SelectedItem:{tag:{wcs_item:"guidebook"}}}] run function wcs:item_abilities/use_guidebook
+# Check for Crafting Scroll
+execute as @a[scores={wcs.use_item=1..},nbt={SelectedItem:{tag:{wcs_item:"crafting_scroll"}}}] run function wcs:game_control/make_crafting_table
+# Check for Lumberjack's Aid (with cooldown)
+execute as @a[scores={wcs.use_item=1..},nbt={SelectedItem:{tag:{wcs_item:"lumberjack_aid"}}},if score @s wcs.mine_wood_cd matches 0] run function wcs:game_control/mine_wood
+execute as @a[scores={wcs.use_item=1..},nbt={SelectedItem:{tag:{wcs_item:"lumberjack_aid"}}},unless score @s wcs.mine_wood_cd matches 0] run tellraw @s {"text":"Lumberjack's Aid is on cooldown!","color":"gray"}
+# Check for Hearthstone
+execute as @a[scores={wcs.use_item=1..},nbt={SelectedItem:{tag:{wcs_item:"hearthstone"}}}] run function wcs:game_control/teleport_spawn
+# Check for Totem of Waya (and consume it)
+execute as @a[scores={wcs.use_item=1..},nbt={SelectedItem:{tag:{wcs_item:"waya_totem"}}}] run function wcs:item_abilities/use_waya_totem
+
+# Reset the score for all players who used an item
+scoreboard players reset @a[scores={wcs.use_item=1..}] wcs.use_item

--- a/WayaCreateDatapack/data/wcs/functions/item_abilities/use_guidebook.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/item_abilities/use_guidebook.mcfunction
@@ -1,0 +1,24 @@
+# WayaCreate's Guidebook - Main Dispatcher
+execute if score @s wcs.progressStage matches 0 run function wcs:guidance/stage_0_intro
+execute if score @s wcs.progressStage matches 1 run function wcs:guidance/stage_1_get_wood
+execute if score @s wcs.progressStage matches 2 run function wcs:guidance/stage_2_craft_tools
+execute if score @s wcs.progressStage matches 3 run function wcs:guidance/stage_3_get_stone
+execute if score @s wcs.progressStage matches 4 run function wcs:guidance/stage_4_find_coal
+execute if score @s wcs.progressStage matches 5 run function wcs:guidance/stage_5_build_shelter
+execute if score @s wcs.progressStage matches 6 run function wcs:guidance/stage_6_get_food
+execute if score @s wcs.progressStage matches 7 run function wcs:guidance/stage_7_find_iron
+execute if score @s wcs.progressStage matches 8 run function wcs:guidance/stage_8_craft_iron_gear
+execute if score @s wcs.progressStage matches 9 run function wcs:guidance/stage_9_find_diamonds
+execute if score @s wcs.progressStage matches 10 run function wcs:guidance/stage_10_craft_diamond_pickaxe
+execute if score @s wcs.progressStage matches 11 run function wcs:guidance/stage_11_mine_obsidian
+execute if score @s wcs.progressStage matches 12 run function wcs:guidance/stage_12_build_nether_portal
+execute if score @s wcs.progressStage matches 13 run function wcs:guidance/stage_13_find_fortress
+execute if score @s wcs.progressStage matches 14 run function wcs:guidance/stage_14_get_blaze_rods
+execute if score @s wcs.progressStage matches 15 run function wcs:guidance/stage_15_craft_eyes_of_ender
+execute if score @s wcs.progressStage matches 16 run function wcs:guidance/stage_16_locate_stronghold
+execute if score @s wcs.progressStage matches 17 run function wcs:guidance/stage_17_activate_end_portal
+execute if score @s wcs.progressStage matches 18 run function wcs:guidance/stage_18_enter_the_end
+execute if score @s wcs.progressStage matches 19 run function wcs:guidance/stage_19_defeat_ender_dragon
+# Fallback for stages not yet fully implemented (e.g. post-dragon)
+execute if score @s wcs.progressStage matches 20.. unless score @s wcs.progressStage matches 100 run tellraw @s {"text":"You consult the Guidebook... More guidance coming soon for this stage!","color":"yellow"}
+execute if score @s wcs.progressStage matches 100 run function wcs:guidance/stage_complete_game # Placeholder for now

--- a/WayaCreateDatapack/data/wcs/functions/item_abilities/use_waya_totem.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/item_abilities/use_waya_totem.mcfunction
@@ -1,0 +1,3 @@
+function wcs:game_control/init_wayacreate_mode
+clear @s minecraft:carrot_on_a_stick{wcs_item:"waya_totem"} 1
+tellraw @s {"text":"The Totem of Waya crumbles to dust as its power flows into you!","color":"red"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/become_ally_to_monsters.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/become_ally_to_monsters.mcfunction
@@ -1,0 +1,12 @@
+# This is a simple version making nearby monsters temporarily passive by putting them on a team.
+# Ensure the team exists and is configured (no friendly fire, etc.)
+team add wcs_allies {"text":"WCS Allies"}
+team modify wcs_allies friendlyFire false
+team modify wcs_allies color green
+execute as @e[type=!minecraft:player,distance=..16,team=!wcs_allies] run team join wcs_allies @s
+execute as @e[type=!minecraft:player,distance=..16,team=wcs_allies] run data merge entity @s {NoAI:0b, Health:20f}
+# Add a temporary effect to them so we can remove them from the team later
+effect give @e[type=!minecraft:player,distance=..16,team=wcs_allies] minecraft:glowing 30 0 true
+tellraw @s {"text":"WayaCreate says: Nearby creatures seem less hostile for a moment...","color":"green"}
+# Schedule a function to remove them from the team after 30 seconds
+schedule function wcs:mob_control/clear_allies_team 30s

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/clear_allies_team.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/clear_allies_team.mcfunction
@@ -1,0 +1,2 @@
+execute as @e[team=wcs_allies,type=!minecraft:player] run team leave @s
+tellraw @a[distance=..64] {"text":"The temporary alliance has ended.","color":"dark_green"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/command_army_attack.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/command_army_attack.mcfunction
@@ -1,0 +1,4 @@
+# This is complex. It requires the player to target an entity, then have army members target it.
+# For now, placeholder: makes army members aggressive (removes NoAI) and they pick their own targets.
+execute as @e[team=wcs_army,type=!minecraft:player] run data merge entity @s {NoAI:0b}
+tellraw @s {"text":"WayaCreate says: Army, attack! (They will choose their own targets for now)","color":"red"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/command_army_follow.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/command_army_follow.mcfunction
@@ -1,0 +1,9 @@
+# Makes members of wcs_army follow the player who issued the command.
+# This requires storing the commander's identity, perhaps by tagging the player.
+tag @s add wcs_army_commander
+# In a tick function, mobs in wcs_army would pathfind to @a[tag=wcs_army_commander,limit=1]
+# For now, a simpler teleport to player who used the item/command.
+# Also ensure NoAI is off so they can move (it's set by 'stay' command)
+execute as @e[team=wcs_army,type=!minecraft:player] run data merge entity @s {NoAI:0b}
+execute as @e[team=wcs_army,type=!minecraft:player] run tp @s @p
+tellraw @s {"text":"WayaCreate says: Army, follow me!","color":"blue"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/command_army_stay.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/command_army_stay.mcfunction
@@ -1,0 +1,4 @@
+# Makes members of wcs_army stop moving.
+execute as @e[team=wcs_army,type=!minecraft:player] run data merge entity @s {NoAI:1b}
+tellraw @s {"text":"WayaCreate says: Army, hold position!","color":"blue"}
+# Need a way to re-enable AI for follow/attack. command_army_follow should set NoAI:0b.

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/dance.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/dance.mcfunction
@@ -1,0 +1,4 @@
+# Makes nearby mobs jump around a bit.
+execute as @e[type=!minecraft:player,distance=..10,type=!minecraft:item,type=!minecraft:arrow,type=!minecraft:experience_orb] at @s run effect give @s minecraft:jump_boost 2 4 true
+execute as @e[type=!minecraft:player,distance=..10,type=!minecraft:item,type=!minecraft:arrow,type=!minecraft:experience_orb] at @s run particle minecraft:note ~ ~1 ~ 0.5 0.5 0.5 0.1 10
+tellraw @s {"text":"WayaCreate says: Everybody dance now!","color":"light_purple"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/force_mob_drops.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/force_mob_drops.mcfunction
@@ -1,0 +1,5 @@
+# Simplified: For now, gives the player an ender pearl if they are looking at an enderman.
+# A full version would use custom loot tables or more specific targeting.
+execute as @s at @s if entity @e[type=minecraft:enderman,distance=..4,limit=1] run give @s minecraft:ender_pearl 1
+execute as @s at @s if entity @e[type=minecraft:enderman,distance=..4,limit=1] run tellraw @s {"text":"WayaCreate says: You managed to snag an ender pearl from the Enderman!","color":"dark_purple"}
+execute as @s at @s unless entity @e[type=minecraft:enderman,distance=..4,limit=1] run tellraw @s {"text":"WayaCreate says: Look closely at an Enderman to use this!","color":"gray"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/make_villagers_trade.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/make_villagers_trade.mcfunction
@@ -1,0 +1,4 @@
+# Simplified: Refreshes trades for villagers near the player.
+# True "force trade" is complex. This will just reset their trades if possible.
+execute as @e[type=minecraft:villager,distance=..8] run data merge entity @s {Offers:{Recipes:[]}}
+tellraw @s {"text":"WayaCreate says: Nearby villagers have refreshed their trades! (Hopefully for the better!)","color":"green"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/recruit_mob.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/recruit_mob.mcfunction
@@ -1,0 +1,6 @@
+# This needs a way to target a mob. For now, assume the mob is within 2 blocks directly in front.
+# More advanced: raycast to find target.
+# Ensure the 'wcs_army' team exists (add to load_setups.mcfunction)
+execute as @e[type=!minecraft:player,distance=..2,limit=1,sort=nearest,team=!wcs_army] at @s run team join wcs_army @s
+execute as @e[type=!minecraft:player,distance=..2,limit=1,sort=nearest,team=wcs_army] at @s run tellraw @p {"text":"WayaCreate says: You've recruited a new member to your army!","color":"blue"}
+execute as @e[type=!minecraft:player,distance=..2,limit=1,sort=nearest,team=!wcs_army] at @s run tellraw @p {"text":"WayaCreate says: Couldn't recruit. Maybe it's already in your army or too far?","color":"yellow"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/summon_pet_cat.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/summon_pet_cat.mcfunction
@@ -1,0 +1,5 @@
+# CatType can be randomized or chosen. For now, default black.
+# Available CatType values: 0 (tabby), 1 (black), 2 (red), 3 (siamese), 4 (british shorthair), 5 (calico), 6 (persian), 7 (ragdoll), 8 (white), 9 (jellie), 10 (all black).
+execute at @s run summon minecraft:cat ~ ~ ~ {CatType:1}
+execute store result entity @e[type=minecraft:cat,distance=..2,limit=1,sort=nearest] Owner set from entity @s UUID
+tellraw @s {"text":"WayaCreate says: A sleek cat appears by your side!","color":"lime"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/summon_pet_fox.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/summon_pet_fox.mcfunction
@@ -1,0 +1,8 @@
+# Trusted requires actual UUIDs.
+# A simpler approach for "pet-like" behavior without full taming if direct Owner tag isn't simple:
+# execute at @s run summon minecraft:fox ~ ~ ~ {CustomName:'{"text":"Player\'s Fox","color":"gold"}', NoAI:0b, PersistenceRequired:1b}
+# Add to a specific "pet_foxes" team that doesn't fight players and maybe follows them via other means.
+# For now, just summon a friendly-named fox.
+# Simpler: Just summon a fox. True taming is complex for foxes via commands.
+execute at @s run summon minecraft:fox ~ ~ ~ {CustomNameVisible:1b, CustomName:'{"text":"WayaCreate\'s Fox"}'}
+tellraw @s {"text":"WayaCreate says: A cunning fox appears! It seems friendly.","color":"lime"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/summon_pet_wolf.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/summon_pet_wolf.mcfunction
@@ -1,0 +1,5 @@
+# Correct way to set owner: execute at @s run summon wolf ~ ~ ~ {Owner:"@p"} (this might not work directly in mcfunction due to selector resolution time)
+# A more robust way is to summon, then use 'data modify entity <wolf_uuid> Owner set from entity @s UUID'
+execute at @s run summon minecraft:wolf ~ ~ ~ {CollarColor:14}
+execute store result entity @e[type=minecraft:wolf,distance=..2,limit=1,sort=nearest] Owner set from entity @s UUID
+tellraw @s {"text":"WayaCreate says: A loyal wolf appears by your side!","color":"lime"}

--- a/WayaCreateDatapack/data/wcs/functions/mob_control/worship_me.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/mob_control/worship_me.mcfunction
@@ -1,0 +1,6 @@
+# Makes nearby villagers and piglins look at the player and maybe play a sound or particle.
+execute as @e[type=minecraft:villager,distance=..10] at @s run effect give @s minecraft:glowing 5 0 true
+execute as @e[type=minecraft:villager,distance=..10] at @s run particle minecraft:happy_villager ~ ~1 ~ 0.5 0.5 0.5 0.1 10
+execute as @e[type=minecraft:piglin,distance=..10,nbt={IsAdmiring:0b}] at @s run data merge entity @s {IsAdmiring:1b}
+execute as @e[type=minecraft:piglin,distance=..10] at @s run particle minecraft:heart ~ ~1 ~ 0.5 0.5 0.5 0.1 5
+tellraw @s {"text":"WayaCreate says: Local villagers and piglins seem quite impressed!","color":"yellow"}

--- a/WayaCreateDatapack/data/wcs/functions/utils/load_setups.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/utils/load_setups.mcfunction
@@ -1,0 +1,27 @@
+scoreboard objectives add wcs.temp dummy
+scoreboard objectives add wcs.mine_wood_cd dummy
+scoreboard objectives add wcs.use_item minecraft.used:minecraft.carrot_on_a_stick
+scoreboard objectives add wcs.progressStage dummy "WCS Player Progression"
+
+# Chat Command Triggers
+scoreboard objectives add wcs.cmd_help trigger "WCS: Show Help"
+scoreboard objectives add wcs.cmd_giveDia trigger "WCS: Give Diamonds"
+scoreboard objectives add wcs.cmd_timeStop trigger "WCS: Stop Time"
+scoreboard objectives add wcs.cmd_timeResume trigger "WCS: Resume Time"
+scoreboard objectives add wcs.cmd_wcModeOn trigger "WCS: WayaCreate Mode ON"
+scoreboard objectives add wcs.cmd_wcModeOff trigger "WCS: WayaCreate Mode OFF"
+
+# wcs_allies team (temporary grouping for become_ally_to_monsters)
+# Clear the wcs_allies team just in case of reload, as it's meant to be temporary.
+team remove wcs_allies
+team add wcs_allies {"text":"WCS Allies"}
+team modify wcs_allies friendlyFire false
+team modify wcs_allies color green
+
+# wcs_army team (for recruited mobs)
+team add wcs_army {"text":"WCS Army"}
+team modify wcs_army friendlyFire false
+team modify wcs_army color blue
+
+# Add other setup commands here as needed
+tellraw @a {"text":"WayaCreateDatapack loaded! WCS utilities initialized. (v6 - Guidance System)","color":"gold"}

--- a/WayaCreateDatapack/data/wcs/functions/utils/reset_mine_wood_cd.mcfunction
+++ b/WayaCreateDatapack/data/wcs/functions/utils/reset_mine_wood_cd.mcfunction
@@ -1,0 +1,1 @@
+scoreboard players set @s wcs.mine_wood_cd 0

--- a/WayaCreateDatapack/data/wcs/recipes/crafting_scroll.json
+++ b/WayaCreateDatapack/data/wcs/recipes/crafting_scroll.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    { "item": "minecraft:paper" },
+    { "item": "minecraft:crafting_table" }
+  ],
+  "result": {
+    "item": "minecraft:carrot_on_a_stick",
+    "count": 1,
+    "nbt": "{display:{Name:'{\"text\":\"Crafting Table Scroll\",\"color\":\"green\",\"italic\":false}',Lore:['{\"text\":\"Right-click to magically conjure a crafting table!\",\"color\":\"aqua\"}','{\"text\":\"(Requires 4 oak planks)\"}' ]},wcs_item:\"crafting_scroll\",CustomModelData:2}"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/recipes/guidebook.json
+++ b/WayaCreateDatapack/data/wcs/recipes/guidebook.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    { "item": "minecraft:book" },
+    { "item": "minecraft:stick" }
+  ],
+  "result": {
+    "item": "minecraft:carrot_on_a_stick",
+    "count": 1,
+    "nbt": "{display:{Name:'{\"text\":\"WayaCreate\\'s Guidebook\",\"color\":\"gold\",\"italic\":false}',Lore:['{\"text\":\"Right-click to get guidance on your journey!\",\"color\":\"yellow\"}']},wcs_item:\"guidebook\",CustomModelData:1}"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/recipes/hearthstone.json
+++ b/WayaCreateDatapack/data/wcs/recipes/hearthstone.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " S ",
+    "SES",
+    " S "
+  ],
+  "key": {
+    "E": { "item": "minecraft:ender_pearl" },
+    "S": { "item": "minecraft:stone" }
+  },
+  "result": {
+    "item": "minecraft:carrot_on_a_stick",
+    "count": 1,
+    "nbt": "{display:{Name:'{\"text\":\"Hearthstone\",\"color\":\"light_purple\",\"italic\":false}',Lore:['{\"text\":\"Right-click to return to your spawn point.\",\"color\":\"aqua\"}' ]},wcs_item:\"hearthstone\",CustomModelData:4}"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/recipes/lumberjack_aid.json
+++ b/WayaCreateDatapack/data/wcs/recipes/lumberjack_aid.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "PS ",
+    "WX ",
+    " X "
+  ],
+  "key": {
+    "P": { "item": "minecraft:paper" },
+    "S": { "item": "minecraft:stick" },
+    "W": { "item": "minecraft:wooden_axe" }
+  },
+  "result": {
+    "item": "minecraft:carrot_on_a_stick",
+    "count": 1,
+    "nbt": "{display:{Name:'{\"text\":\"Lumberjack\\'s Aid\",\"color\":\"dark_green\",\"italic\":false}',Lore:['{\"text\":\"Right-click while facing trees to quickly gather wood.\",\"color\":\"yellow\"}' ]},wcs_item:\"lumberjack_aid\",CustomModelData:3}"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/recipes/waya_totem.json
+++ b/WayaCreateDatapack/data/wcs/recipes/waya_totem.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    { "item": "minecraft:gold_block" },
+    { "item": "minecraft:diamond" },
+    { "item": "minecraft:emerald" },
+    { "item": "minecraft:totem_of_undying" }
+  ],
+  "result": {
+    "item": "minecraft:carrot_on_a_stick",
+    "count": 1,
+    "nbt": "{display:{Name:'{\"text\":\"Totem of Waya\",\"color\":\"gold\",\"italic\":false}',Lore:['{\"text\":\"Right-click to activate WayaCreate Mode!\",\"color\":\"red\"}','{\"text\":\"(Consumable)\"}' ]},wcs_item:\"waya_totem\",CustomModelData:5}"
+  }
+}

--- a/WayaCreateDatapack/data/wcs/tags/items/cooked_meats.json
+++ b/WayaCreateDatapack/data/wcs/tags/items/cooked_meats.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:cooked_beef",
+    "minecraft:cooked_porkchop",
+    "minecraft:cooked_mutton",
+    "minecraft:cooked_chicken",
+    "minecraft:cooked_rabbit",
+    "minecraft:cooked_salmon",
+    "minecraft:cooked_cod"
+  ]
+}

--- a/WayaCreateDatapack/pack.mcmeta
+++ b/WayaCreateDatapack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 15,
+    "description": "WayaCreate Says - Datapack Edition"
+  }
+}


### PR DESCRIPTION
This commit significantly expands the 'Help Me Beat The Game' feature by implementing a multi-stage guidance and feedback system.

Key changes:
- **Progression Scoreboard:** Introduced `wcs.progressStage` to track your advancement.
- **Guidebook Dispatcher:** The `use_guidebook.mcfunction` now directs you to stage-specific guidance based on your `wcs.progressStage`.
- **Advancements & Rewards:** Created numerous advancements (e.g., `get_first_log`, `craft_full_iron_gear`, `enter_nether`, `locate_stronghold`) that trigger reward functions upon completion. These functions update your progress, provide feedback messages, and unlock placeholder recipes for custom items.
- **Guidance Functions:** Developed specific `.mcfunction` files for each of the 20 progression stages (0-19), from initial wood gathering through to entering The End and receiving instructions for the Ender Dragon fight. These functions use `tellraw` and `title` commands to guide you.
- **Item System Integration:** The guidance system is designed to be used with the previously implemented custom 'WayaCreate's Guidebook' item. Placeholder recipes for other helper items are granted at appropriate stages.
- **Chat System Integration:** While not directly modified, the guidance system complements the chat system by providing the main progression path.

The implemented stages cover:
- Early game survival (wood, crafting, tools, shelter, food).
- Mid-game progression (iron, diamonds, obsidian).
- Nether exploration (portal, fortress, blaze rods).
- Journey to The End (Eyes of Ender, stronghold, End Portal activation, entering The End).

The system is now poised for the final stage: detecting Ender Dragon defeat and providing concluding messages.